### PR TITLE
 APIVOTAL-70 Initial image facade implementation 

### DIFF
--- a/black-duck-broker/src/main/java/com/blackducksoftware/integration/perceptor/model/Image.java
+++ b/black-duck-broker/src/main/java/com/blackducksoftware/integration/perceptor/model/Image.java
@@ -11,9 +11,6 @@
  */
 package com.blackducksoftware.integration.perceptor.model;
 
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -21,15 +18,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public final class Image {
-    @JsonProperty("DockerImage")
+    @JsonProperty("Repository")
     private String repository;
 
-    // @JsonProperty("Tags")
-    @JsonIgnore
-    private List<String> tags;
-
-    @JsonProperty("Name")
-    private String name;
+    @JsonProperty("Tag")
+    private String tag;
 
     @JsonProperty("Sha")
     private String sha;
@@ -46,20 +39,12 @@ public final class Image {
         this.repository = repository;
     }
 
-    public final List<String> getTags() {
-        return tags;
+    public final String getTag() {
+        return tag;
     }
 
-    public final void setTags(List<String> tags) {
-        this.tags = tags;
-    }
-
-    public final String getName() {
-        return name;
-    }
-
-    public final void setName(String name) {
-        this.name = name;
+    public final void setTag(String tag) {
+        this.tag = tag;
     }
 
     public final String getSha() {

--- a/black-duck-img-facade/.gitignore
+++ b/black-duck-img-facade/.gitignore
@@ -1,0 +1,26 @@
+.gradle
+/build/
+/bin/
+/test-output/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings/
+.springBeans
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/

--- a/black-duck-img-facade/build.gradle
+++ b/black-duck-img-facade/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+  id 'java'
+  id 'application'
+  id 'eclipse-wtp'
+  id 'jacoco'
+  id 'com.github.kt3k.coveralls' version '2.8.1'
+}
+
+apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
+
+sourceCompatibility = 1.8
+mainClassName = 'com.blackducksoftware.integration.cloudfoundry.imagefacade.BDServiceBrokerImageFacade'
+
+// In this section you declare where to find the dependencies of your project
+repositories {
+    jcenter()
+}
+
+dependencies {
+  compile('org.springframework.boot:spring-boot-starter-web') {
+    exclude group: 'org.apache.tomcat', module: 'tomcat-annotations-api'
+    exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-el'
+    exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-core'
+    exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-websocket'
+  }
+  compile('org.apache.tomcat:tomcat-annotations-api:8.5.32') // Update version based on Co-Pilot report
+  compile('org.apache.tomcat.embed:tomcat-embed-el:8.5.32') // Update version based on Co-Pilot report
+  compile('org.apache.tomcat.embed:tomcat-embed-core:8.5.32') // Update version based on Co-Pilot report
+  compile('org.apache.tomcat.embed:tomcat-embed-websocket:8.5.32') // Update version based on Co-Pilot report
+  compile('org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.0.1.RELEASE') {
+    exclude group: 'org.springframework.security.oauth', module: 'spring-security-oauth2'
+  }
+  compile('org.springframework.security.oauth:spring-security-oauth2:2.3.3.RELEASE') // Update version based on Co-Pilot report
+  compile('org.springframework.boot:spring-boot-configuration-processor')
+  compile('org.apache.httpcomponents:httpclient:4.5.5')
+  compile('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6')
+  compile('com.google.code.findbugs:jsr305:3.0.2')
+  compile('org.cloudfoundry:cloudfoundry-client-reactor:3.12.0.RELEASE')
+  testCompile('org.springframework.boot:spring-boot-starter-test') { 
+    exclude group: 'junit', module: 'junit'
+  }
+  testCompile('org.testng:testng:6.11')
+}
+
+test{
+  useTestNG() {
+    listeners << 'org.testng.reporters.XMLReporter'
+  }
+}
+
+jacocoTestReport {
+  reports { xml.enabled = true }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/BDServiceBrokerImageFacade.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/BDServiceBrokerImageFacade.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+
+/**
+ * @author fisherj
+ *
+ */
+@SpringBootApplication
+@EnableOAuth2Client
+@EnableWebSecurity
+@EnableAsync
+public class BDServiceBrokerImageFacade {
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(BDServiceBrokerImageFacade.class, args);
+    }
+
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/CloudControllerConfiguration.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/CloudControllerConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.cloudfoundry.reactor.DefaultConnectionContext;
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+import org.cloudfoundry.reactor.tokenprovider.ClientCredentialsGrantTokenProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
+
+/**
+ * @author fisherj
+ *
+ */
+@Configuration
+public class CloudControllerConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(CloudControllerConfiguration.class);
+
+    @Bean
+    @ConfigurationProperties("cf.oauth2.client")
+    protected ClientCredentialsResourceDetails oAuthDetails() {
+        return new ClientCredentialsResourceDetails();
+    }
+
+    @Bean
+    public ReactorCloudFoundryClient reactorCloudFoundryClient(
+            @Value("${cf.baseUrl}") String baseUrlString,
+            @Value("${cf.skip-ssl-validation}") boolean insecure,
+            ClientCredentialsResourceDetails oauthDetails) throws MalformedURLException {
+        logger.trace("In reactorCloudFoundryClient with args: baseUrl: {}, insecure: {}, oauthClientId: {}", baseUrlString, insecure,
+                oauthDetails.getClientId());
+        URL baseUrl = new URL(baseUrlString);
+        DefaultConnectionContext.Builder conxCtxBuilder = DefaultConnectionContext.builder()
+                .apiHost(baseUrl.getHost())
+                .port(baseUrl.getPort())
+                .skipSslValidation(insecure);
+
+        ClientCredentialsGrantTokenProvider.Builder oauthTokenProviderBuilder = ClientCredentialsGrantTokenProvider.builder()
+                .clientId(oauthDetails.getClientId())
+                .clientSecret(oauthDetails.getClientSecret());
+
+        return ReactorCloudFoundryClient.builder()
+                .connectionContext(conxCtxBuilder.build())
+                .tokenProvider(oauthTokenProviderBuilder.build())
+                .build();
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/ImageFacadeConfiguration.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/ImageFacadeConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;
+
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.impl.ImageFacadeService;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.impl.ImagePuller;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.model.ImageModel;
+
+/**
+ * @author fisherj
+ *
+ */
+@Configuration
+@Import(CloudControllerConfiguration.class)
+public class ImageFacadeConfiguration {
+    @Value("${application.dropletLocation}")
+    private String dropletLocation;
+
+    @Value("${application.pullRetries}")
+    private int retries;
+
+    @Value("${application.pullTimeoutSeconds}")
+    private int pullTimeoutSeconds;
+
+    @Autowired
+    ReactorCloudFoundryClient cloudFoundryClient;
+
+    @Bean
+    public ImageFacadeService imageFacadeService() {
+        return new ImageFacadeService(imageModel(), dropletLocation);
+    }
+
+    @Bean
+    public ImageModel imageModel() {
+        return new ImageModel(imagePuller());
+    }
+
+    @Bean
+    public ImagePuller imagePuller() {
+        return new ImagePuller(cloudFoundryClient, dropletLocation, retries, pullTimeoutSeconds);
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/CheckImageResponse.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/CheckImageResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author fisherj
+ *
+ */
+public final class CheckImageResponse {
+    private final String pullSpec;
+
+    private final String imageStatus;
+
+    @JsonCreator
+    public CheckImageResponse(String pullSpec, String imageStatus) {
+        this.pullSpec = pullSpec;
+        this.imageStatus = imageStatus;
+    }
+
+    @JsonProperty(value = "PullSpec")
+    public final String getPullSpec() {
+        return pullSpec;
+    }
+
+    @JsonProperty(value = "ImageStatus")
+    public final String getImageStatus() {
+        return imageStatus;
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/CheckImageResponse.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/CheckImageResponse.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public final class CheckImageResponse {
     private final String pullSpec;
 
-    private final String imageStatus;
+    private final int imageStatus;
 
     @JsonCreator
-    public CheckImageResponse(String pullSpec, String imageStatus) {
+    public CheckImageResponse(String pullSpec, int imageStatus) {
         this.pullSpec = pullSpec;
         this.imageStatus = imageStatus;
     }
@@ -35,7 +35,7 @@ public final class CheckImageResponse {
     }
 
     @JsonProperty(value = "ImageStatus")
-    public final String getImageStatus() {
+    public final int getImageStatus() {
         return imageStatus;
     }
 }

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/Image.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/Image.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.api;
+
+import java.util.Objects;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author fisherj
+ *
+ */
+@Validated
+public final class Image {
+    public static final String DELIMITER = "@sha256:";
+
+    private final String pullSpec;
+
+    @JsonCreator
+    public Image(@JsonProperty("PullSpec") String pullSpec) {
+        this.pullSpec = pullSpec;
+    }
+
+    public final String getPullSpec() {
+        return pullSpec;
+    }
+
+    @JsonIgnore
+    public final String asAppId() {
+        return pullSpec.split(DELIMITER)[0];
+    }
+
+    @JsonIgnore
+    public final String asSha() {
+        return pullSpec.split(DELIMITER)[1];
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pullSpec);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Image)) {
+            return false;
+        }
+
+        Image otherPullSpec = (Image) other;
+        return Objects.equals(getPullSpec(), otherPullSpec.getPullSpec());
+    }
+
+    @Override
+    public String toString() {
+        return getPullSpec();
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/api/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.api;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/exception/ImagePullerException.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/exception/ImagePullerException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.exception;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+
+/**
+ * @author fisherj
+ *
+ */
+public class ImagePullerException extends RuntimeException {
+    private final Image image;
+
+    public ImagePullerException(String message, Image image) {
+        super(message);
+        this.image = image;
+    }
+
+    public ImagePullerException(String message, Throwable throwable, Image image) {
+        super(message, throwable);
+        this.image = image;
+    }
+
+    public ImagePullerException(Throwable throwable, Image image) {
+        super(throwable);
+        this.image = image;
+    }
+
+    public final Image getImage() {
+        return image;
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/exception/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/exception/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.exception;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImageFacadeService.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImageFacadeService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.model.ImageModel;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.model.ImageStatus;
+
+/**
+ * @author fisherj
+ *
+ */
+public class ImageFacadeService {
+    private static final Logger logger = LoggerFactory.getLogger(ImageFacadeService.class);
+
+    private final String dropletLocation;
+
+    private final ImageModel imageModel;
+
+    public ImageFacadeService(ImageModel imageModel, String dropletLocation) {
+        this.dropletLocation = dropletLocation;
+        this.imageModel = imageModel;
+    }
+
+    public boolean pullImage(Image image) {
+        logger.trace("entering pullImage");
+        boolean result = false;
+        try {
+            result = imageModel.pullImage(image, dropletLocation);
+        } catch (Exception e) {
+            logger.error("fatal error executing image pull", e);
+        }
+        logger.trace("exiting pullImage");
+        return result;
+    }
+
+    public ImageStatus checkImage(Image image) {
+        return imageModel.getImageStatus(image);
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImagePuller.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImagePuller.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.time.Duration;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.applications.DownloadApplicationDropletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.util.concurrent.ListenableFuture;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.exception.ImagePullerException;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.model.ImagePullerResult;
+
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * @author fisherj
+ *
+ */
+public class ImagePuller {
+    private static final Logger logger = LoggerFactory.getLogger(ImagePuller.class);
+
+    private final String dropletLocation;
+
+    private final CloudFoundryClient cloudFoundryClient;
+
+    private final int retries;
+
+    private final int pullTimeoutSeconds;
+
+    public ImagePuller(CloudFoundryClient cloudFoundryClient, String dropletLocation, int retries, int pullTimeoutSeconds) {
+        this.cloudFoundryClient = cloudFoundryClient;
+        this.dropletLocation = dropletLocation;
+        this.retries = retries;
+        this.pullTimeoutSeconds = pullTimeoutSeconds;
+    }
+
+    @Async
+    public ListenableFuture<ImagePullerResult> pull(Image image) throws Exception {
+        logger.trace("start pull of image for app: {}", image.asAppId());
+
+        Path location = Paths.get(dropletLocation, image.getPullSpec());
+        logger.trace("image pull, file location: {}", location);
+
+        Status status = new Status(retries);
+        do {
+            logger.trace("pull image {}", status);
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            Path retPath = cloudFoundryClient.applicationsV2()
+                    .downloadDroplet(DownloadApplicationDropletRequest.builder()
+                            .applicationId(image.asAppId())
+                            .build())
+                    .onErrorMap((e) -> {
+                        logger.error("fatal issue downloading image", e);
+                        return new ImagePullerException("issue with remote image", e, image);
+                    })
+                    .publishOn(Schedulers.elastic())
+                    .reduceWith(() -> {
+                        try {
+                            return Files.newOutputStream(location);
+                        } catch (IOException e) {
+                            // This will cause the processing of this Reactive Stream to stop immediately
+                            throw new ImagePullerException("issue with output file", e, image);
+                        }
+                    }, (out, bytes) -> {
+                        try {
+                            md.update(bytes);
+                            out.write(bytes);
+                            return out;
+                        } catch (IOException e) {
+                            // This will cause the processing of this Reactive Stream to stop immediately
+                            throw new ImagePullerException("issue writing data", e, image);
+                        }
+                    })
+                    .doOnSuccessOrError((out, t) -> {
+                        try {
+                            if (out != null) {
+                                out.close();
+                            }
+                        } catch (IOException e) {
+                            // This will cause the processing of this Reactive Stream to stop immediately
+                            throw new ImagePullerException(e, image);
+                        }
+                    })
+                    .doOnSuccess(out -> {
+                        // Check the retrieved file checksum against the expected to ensure read parity
+                        String computedSha = convertDigestBytesToHex(md.digest());
+                        logger.trace("computed file hash: {}, for image: {}", computedSha, image);
+                        if (!image.asSha().equals(computedSha)) {
+                            logger.debug("computed sha: {} did not match expected: {}", computedSha, image.asSha());
+                            status.shaInvalid();
+                        } else {
+                            status.pass();
+                        }
+                    })
+                    .doOnError((e) -> {
+                        // No need to update "status" here as exception will cause processing to stop
+                        logger.error("image pull fatal error:", e);
+                    })
+                    .map(out -> location)
+                    .block(Duration.ofSeconds(pullTimeoutSeconds));
+            if (retPath == null) {
+                logger.debug("image pull of image: {} timed out", image);
+                status.timeout();
+            }
+        } while (status.shouldRetry());
+
+        logger.trace("end pull of image: {}", image.asAppId());
+        return new AsyncResult<ImagePullerResult>(new ImagePullerResult(image, status.getError()));
+    }
+
+    private static String convertDigestBytesToHex(byte[] mdBytes) {
+        StringBuffer hexString = new StringBuffer();
+        for (byte mdByte : mdBytes) {
+            hexString.append(Integer.toString((mdByte & 0xff) + 0x100, 16).substring(1));
+        }
+
+        return hexString.toString();
+    }
+
+    private static class Status {
+        private final int retries;
+
+        private int attempt;
+
+        private boolean pass;
+
+        private String error = null;
+
+        public Status(int retries) {
+            this.retries = retries;
+            attempt = 1;
+            pass = true;
+        }
+
+        public void timeout() {
+            attempt++;
+            pass = false;
+            error = "image pull timeout";
+        }
+
+        public void shaInvalid() {
+            attempt++;
+            pass = false;
+            error = "computed checksum did not match expected";
+        }
+
+        public void pass() {
+            pass = true;
+            error = null;
+        }
+
+        public boolean shouldRetry() {
+            boolean ret = true;
+            if ((attempt > retries) || pass) {
+                ret = false;
+            }
+
+            return ret;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("attempt %d of %d, last attempt error: %s", attempt, retries, error);
+        }
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImagePuller.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/ImagePuller.java
@@ -58,7 +58,7 @@ public class ImagePuller {
     public ListenableFuture<ImagePullerResult> pull(Image image) throws Exception {
         logger.trace("start pull of image for app: {}", image.asAppId());
 
-        Path location = Paths.get(dropletLocation, image.getPullSpec());
+        Path location = Paths.get(dropletLocation, image.getPullSpec() + ".tar");
         logger.trace("image pull, file location: {}", location);
 
         Status status = new Status(retries);

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/impl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.impl;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImageModel.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImageModel.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.exception.ImagePullerException;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.impl.ImagePuller;
+
+/**
+ * @author fisherj
+ *
+ */
+public final class ImageModel implements ListenableFutureCallback<ImagePullerResult> {
+    private static final Logger logger = LoggerFactory.getLogger(ImageModel.class);
+
+    private ModelState modelState;
+
+    private Map<Image, ImageStatus> status = new HashMap<>();
+
+    private ImagePuller imagePuller;
+
+    public ImageModel(ImagePuller imagePuller) {
+        modelState = ModelState.READY;
+        this.imagePuller = imagePuller;
+    }
+
+    public boolean pullImage(Image image, String dropletLocation) throws Exception {
+        if (ModelState.READY != modelState) {
+            logger.error("unable to pull image  for app {}, image pull in progress {}", image.asAppId(), modelState);
+            return false;
+        }
+
+        logger.info("about to start pulling image for app {} -- model state {}", image.asAppId(), modelState);
+        if (null != status.put(image, ImageStatus.INPROGRESS)) {
+            logger.warn("ImageModel status already contains value for key: {}, replacing value", image);
+        }
+        modelState = ModelState.PULLING;
+        ListenableFuture<ImagePullerResult> f = imagePuller.pull(image);
+        f.addCallback(this);
+        logger.trace("added callback for image: {}, exiting pullImage", image);
+        return true;
+    }
+
+    public ImageStatus getImageStatus(Image image) {
+        return status.getOrDefault(image, ImageStatus.UNKNOWN);
+    }
+
+    @Override
+    public void onSuccess(ImagePullerResult result) {
+        logger.debug("Completed image pull task for image: {}", result.getImage());
+        if (!result.getError().isPresent()) {
+            logger.info("Successfully finished image pull for image: {}", result.getImage());
+            status.put(result.getImage(), ImageStatus.DONE);
+        } else {
+            logger.info("finished image pull for image: {} with error: {}", result.getImage(), result.getError().get());
+            status.put(result.getImage(), ImageStatus.ERROR);
+        }
+        modelState = ModelState.READY;
+    }
+
+    @Override
+    public void onFailure(Throwable ex) {
+        logger.error("Fatal error completing image pull task", ex);
+        if (ex instanceof ImagePullerException) {
+            ImagePullerException ipe = (ImagePullerException) ex;
+            logger.debug("attempting to remove image: {} from status map", ipe.getImage());
+            status.remove(ipe.getImage());
+        }
+        modelState = ModelState.READY;
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImagePullerResult.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImagePullerResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.model;
+
+import java.util.Optional;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+
+/**
+ * @author fisherj
+ *
+ */
+public final class ImagePullerResult {
+    private final Image image;
+
+    private final Optional<String> error;
+
+    public ImagePullerResult(Image image, String error) {
+        this.image = image;
+        this.error = Optional.ofNullable(error);
+    }
+
+    public final Image getImage() {
+        return image;
+    }
+
+    public final Optional<String> getError() {
+        return error;
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImageStatus.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ImageStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.model;
+
+/**
+ * @author fisherj
+ *
+ */
+public enum ImageStatus {
+    UNKNOWN("Unknown"),
+    INPROGRESS("InProgress"),
+    DONE("Done"),
+    ERROR("Error");
+
+    private final String value;
+
+    private ImageStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return name() + "(" + value() + ")";
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ModelState.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/ModelState.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.model;
+
+/**
+ * @author fisherj
+ *
+ */
+public enum ModelState {
+    READY("ModelStateReady"),
+    PULLING("ModelStatePulling");
+
+    private final String desc;
+
+    private ModelState(String desc) {
+        this.desc = desc;
+    }
+
+    private final String getDesc() {
+        return desc;
+    }
+
+    @Override
+    public String toString() {
+        return name() + "(" + getDesc() + ")";
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/model/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.model;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/security/ApplicationSecurity.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/security/ApplicationSecurity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * @author fisherj
+ *
+ */
+@Configuration
+public class ApplicationSecurity extends WebSecurityConfigurerAdapter {
+    @Autowired
+    public ApplicationSecurity() {
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // Disable basic auth
+        http.csrf().disable().authorizeRequests().anyRequest().authenticated().and().httpBasic().disable().authorizeRequests().anyRequest().permitAll();
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/security/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/security/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.security;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/ImageFacadeRestServer.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/ImageFacadeRestServer.java
@@ -62,6 +62,6 @@ public class ImageFacadeRestServer {
     public ResponseEntity<CheckImageResponse> checkImage(@Valid @RequestBody Image body) {
         logger.info("Entered POST check image");
         logger.trace("Checking pullSpec: {}", body);
-        return new ResponseEntity<>(new CheckImageResponse(body.getPullSpec(), imageFacadeService.checkImage(body).value()), HttpStatus.OK);
+        return new ResponseEntity<>(new CheckImageResponse(body.getPullSpec(), imageFacadeService.checkImage(body).ordinal()), HttpStatus.OK);
     }
 }

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/ImageFacadeRestServer.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/ImageFacadeRestServer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.server;
+
+import java.util.Collections;
+
+import javax.validation.Valid;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.CheckImageResponse;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.impl.ImageFacadeService;
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.validation.ImageValidator;
+
+/**
+ * @author fisherj
+ *
+ */
+@Controller
+public class ImageFacadeRestServer {
+    private final Logger logger = LoggerFactory.getLogger(ImageFacadeRestServer.class);
+
+    private final ImageFacadeService imageFacadeService;
+
+    @InitBinder
+    protected void initBinder(WebDataBinder binder) {
+        binder.addValidators(new ImageValidator());
+    }
+
+    @Autowired
+    public ImageFacadeRestServer(ImageFacadeService imageFacadeService) {
+        this.imageFacadeService = imageFacadeService;
+    }
+
+    @PostMapping(path = "/pullimage")
+    public ResponseEntity<?> pullImage(@Valid @RequestBody Image body) {
+        logger.info("Entered POST pull image");
+        HttpStatus respCode = imageFacadeService.pullImage(body) ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;
+        return new ResponseEntity<>(Collections.emptyMap(), respCode);
+    }
+
+    @PostMapping(path = "/checkimage")
+    public ResponseEntity<CheckImageResponse> checkImage(@Valid @RequestBody Image body) {
+        logger.info("Entered POST check image");
+        logger.trace("Checking pullSpec: {}", body);
+        return new ResponseEntity<>(new CheckImageResponse(body.getPullSpec(), imageFacadeService.checkImage(body).value()), HttpStatus.OK);
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/server/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.server;

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/validation/ImageValidator.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/validation/ImageValidator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.validation;
+
+import java.util.regex.Pattern;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+import com.blackducksoftware.integration.cloudfoundry.imagefacade.api.Image;
+
+/**
+ * @author fisherj
+ *
+ */
+public final class ImageValidator implements Validator {
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return Image.class.equals(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "pullSpec", "errors.pullSpec.emptyOrWhitespace");
+
+        Image image = (Image) target;
+
+        if (!validSpecPattern(image.getPullSpec())) {
+            errors.rejectValue("pullSpec", "errors.pullSpec.incorrectFormat");
+        }
+    }
+
+    private boolean validSpecPattern(String spec) {
+        Pattern pattern = Pattern.compile("([\\p{XDigit}-]++)" + Image.DELIMITER + "([\\p{XDigit}-]++)");
+        return pattern.matcher(spec).matches();
+    }
+}

--- a/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/validation/package-info.java
+++ b/black-duck-img-facade/src/main/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/validation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @author fisherj
+ *
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade.validation;

--- a/black-duck-img-facade/src/main/resources/application.yml
+++ b/black-duck-img-facade/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+server:
+  port: 8891
+spring:
+  main:
+    banner-mode: 'OFF'
+  application:
+    name: black-duck-img-facade
+application:
+  realm: BlackDuckSoftware
+  dropletLocation: '/tmp/cf/droplets'
+  pullRetries: 3
+  pullTimeoutSeconds: 300
+cf:
+  baseUrl: https://api.bosh-lite.com
+  skip-ssl-validation: false
+  oauth2:
+    client:
+      id: Cloud Foundry
+      grantType: client_credentials
+      clientId: black-duck-broker
+      clientSecret: 'cf_pass'
+      accessTokenUri: https://uaa.bosh-lite.com/oauth/token
+      scope: cloud_controller.admin
+logging:
+  level:
+    root: WARN

--- a/black-duck-img-facade/src/main/resources/messages.properties
+++ b/black-duck-img-facade/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+errors.pullSpec.emptyOrWhitespace=PullSpec must contain a value
+errors.pullSpec.incorrectFormat=PullSpec format incorrect

--- a/black-duck-img-facade/src/test/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/BDServiceBrokerImageFacadeTest.java
+++ b/black-duck-img-facade/src/test/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/BDServiceBrokerImageFacadeTest.java
@@ -1,0 +1,9 @@
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;
+
+import org.testng.annotations.Test;
+
+public class BDServiceBrokerImageFacadeTest {
+    @Test
+    public void f() {
+    }
+}

--- a/black-duck-img-facade/src/test/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/ImageFacadeTestFactory.java
+++ b/black-duck-img-facade/src/test/java/com/blackducksoftware/integration/cloudfoundry/imagefacade/ImageFacadeTestFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.cloudfoundry.imagefacade;
+
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+/**
+ * @author fisherj
+ *
+ */
+public class ImageFacadeTestFactory {
+    @Factory
+    @Test
+    public Object[] tests() {
+        return new Object[] {
+
+        };
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':black-duck-broker'
+include ':black-duck-img-facade'
 include ':black-duck-decorator'


### PR DESCRIPTION

APIVOTAL-70 Initial image facade implementation  …
**Description:**
Provide an initial implementation of an image facade to work with Pivotal Cloud Foundry (PCF). This implementation:
* Implements the Rest Endpoints /pullimage and /checkimage so that the image scanner can interact with this component
* Retrieves the image \(droplet\) for the specified application using the cf_client_java API
* Computes the checksum of the downloaded image and compares against the expected value provided in the /pullimage request
* Stores in memory, the status of all image downloads
* Minor changes to image facade API and Perceiver Image model to align with the up-to-date Peceptor Swagger doc.